### PR TITLE
Add Onyx anonymizing router MVP

### DIFF
--- a/onyx-core/.gitignore
+++ b/onyx-core/.gitignore
@@ -1,0 +1,4 @@
+/target
+**/keys
+**/services
+Cargo.lock

--- a/onyx-core/Cargo.toml
+++ b/onyx-core/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+members = [
+    "shared",
+    "entry_node",
+    "middle_node",
+    "exit_node",
+    "client"
+]
+resolver = "2"

--- a/onyx-core/README.md
+++ b/onyx-core/README.md
@@ -1,0 +1,30 @@
+# Onyx Routing System
+
+This is a minimal demonstration of an anonymizing router combining onion and garlic routing principles using Rust.
+
+## Structure
+- `shared` – common cryptography utilities, packet types and service resolver.
+- `entry_node`, `middle_node`, `exit_node` – three hop nodes that decrypt a layer and forward the packet.
+- `client` – builds an onion/garlic packet and sends it through the network.
+
+## Running
+1. Ensure you have Rust installed.
+2. Build the workspace:
+   ```bash
+   cargo build --workspace
+   ```
+3. In separate terminals, run each node:
+   ```bash
+   cargo run -p entry_node
+   cargo run -p middle_node
+   cargo run -p exit_node
+   ```
+4. After starting the exit node for the first time, copy its generated public key into a `services.txt` file:
+   ```
+   echo.ony <contents of exit_node/services/echo.ony/public.pem>
+   ```
+5. With `services.txt` in place, run the client:
+   ```bash
+   cargo run -p client
+   ```
+Nodes will log each routing step and the final service prints the received messages.

--- a/onyx-core/client/Cargo.toml
+++ b/onyx-core/client/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "client"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+shared = { path = "../shared" }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+base64 = "0.21"

--- a/onyx-core/client/src/main.rs
+++ b/onyx-core/client/src/main.rs
@@ -1,0 +1,51 @@
+use shared::crypto::{load_or_generate_keys, encrypt_layer, rsa_public_from_pem};
+use shared::packet::{GarlicPacket, Message, HopData, ExitHop};
+use tokio::{net::TcpStream, io::AsyncWriteExt};
+use base64::{engine::general_purpose, Engine as _};
+use shared::resolver::{load_resolver, resolve};
+use std::fs;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // load service resolution file
+    load_resolver("services.txt");
+
+    // load node public keys
+    let entry_pub = rsa_public_from_pem(&fs::read_to_string("entry_node/keys/public.pem")?);
+    let middle_pub = rsa_public_from_pem(&fs::read_to_string("middle_node/keys/public.pem")?);
+    let exit_pub = rsa_public_from_pem(&fs::read_to_string("exit_node/keys/public.pem")?);
+
+    // messages to send
+    let msgs = vec![
+        Message { destination: "user1".into(), body: "Hello 1".into() },
+        Message { destination: "user2".into(), body: "Hello 2".into() },
+    ];
+
+    let service_domain = "echo.ony";
+    let service_pub = resolve(service_domain).expect("service not found");
+
+    let garlic = GarlicPacket { messages: msgs };
+    let garlic_json = serde_json::to_vec(&garlic)?;
+    let service_layer = encrypt_layer(&garlic_json, &service_pub);
+    let service_layer_json = serde_json::to_vec(&service_layer)?;
+
+    let exit_hop = ExitHop { domain: service_domain.to_string(), inner: general_purpose::STANDARD.encode(service_layer_json) };
+    let exit_hop_json = serde_json::to_vec(&exit_hop)?;
+    let exit_layer = encrypt_layer(&exit_hop_json, &exit_pub);
+    let exit_layer_json = serde_json::to_vec(&exit_layer)?;
+
+    let middle_hop = HopData { next: Some("127.0.0.1:7002".into()), inner: general_purpose::STANDARD.encode(exit_layer_json) };
+    let middle_hop_json = serde_json::to_vec(&middle_hop)?;
+    let middle_layer = encrypt_layer(&middle_hop_json, &middle_pub);
+    let middle_layer_json = serde_json::to_vec(&middle_layer)?;
+
+    let entry_hop = HopData { next: Some("127.0.0.1:7001".into()), inner: general_purpose::STANDARD.encode(middle_layer_json) };
+    let entry_layer = encrypt_layer(&serde_json::to_vec(&entry_hop)?, &entry_pub);
+
+    let packet = serde_json::to_string(&entry_layer)?;
+    let mut stream = TcpStream::connect("127.0.0.1:7000").await?;
+    stream.write_all(packet.as_bytes()).await?;
+    stream.write_all(b"\n").await?;
+    println!("Client sent packet");
+    Ok(())
+}

--- a/onyx-core/entry_node/Cargo.toml
+++ b/onyx-core/entry_node/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "entry_node"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+shared = { path = "../shared" }
+tokio = { version = "1", features = ["full"] }
+serde_json = "1"
+anyhow = "1"
+base64 = "0.21"
+rsa = "0.9"

--- a/onyx-core/entry_node/src/main.rs
+++ b/onyx-core/entry_node/src/main.rs
@@ -1,0 +1,37 @@
+use shared::crypto::{load_or_generate_keys, decrypt_layer};
+use shared::packet::HopData;
+use tokio::{net::{TcpListener, TcpStream}, io::{AsyncWriteExt, AsyncBufReadExt, BufReader}};
+use base64::{engine::general_purpose, Engine as _};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let (priv_key, _pub_key) = load_or_generate_keys("entry_node/keys");
+    let listener = TcpListener::bind("127.0.0.1:7000").await?;
+    println!("Entry node listening on 7000");
+    loop {
+        let (mut socket, _) = listener.accept().await?;
+        let priv_key = priv_key.clone();
+        tokio::spawn(async move {
+            if let Err(e) = handle_client(&priv_key, &mut socket).await {
+                eprintln!("entry node error: {e}");
+            }
+        });
+    }
+}
+
+async fn handle_client(priv_key: &rsa::RsaPrivateKey, socket: &mut TcpStream) -> anyhow::Result<()> {
+    let mut reader = BufReader::new(socket);
+    let mut line = String::new();
+    reader.read_line(&mut line).await?;
+    let layer: shared::crypto::OnionLayer = serde_json::from_str(&line.trim())?;
+    let decrypted = decrypt_layer(layer, priv_key);
+    let hop: HopData = serde_json::from_slice(&decrypted)?;
+    if let Some(next) = hop.next {
+        println!("Entry -> forwarding to {next}");
+        let inner = general_purpose::STANDARD.decode(hop.inner)?;
+        let mut stream = TcpStream::connect(next).await?;
+        stream.write_all(&inner).await?;
+        stream.write_all(b"\n").await?;
+    }
+    Ok(())
+}

--- a/onyx-core/exit_node/Cargo.toml
+++ b/onyx-core/exit_node/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "exit_node"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+shared = { path = "../shared" }
+tokio = { version = "1", features = ["full"] }
+serde_json = "1"
+anyhow = "1"
+base64 = "0.21"
+rsa = "0.9"

--- a/onyx-core/exit_node/src/main.rs
+++ b/onyx-core/exit_node/src/main.rs
@@ -1,0 +1,55 @@
+use shared::crypto::{load_or_generate_keys, decrypt_layer};
+use shared::packet::{HopData, ExitHop, GarlicPacket, Message};
+use tokio::{net::{TcpListener, TcpStream}, io::{AsyncWriteExt, AsyncBufReadExt, BufReader}};
+use base64::{engine::general_purpose, Engine as _};
+use shared::crypto::{rsa_private_from_pem, rsa_public_to_pem, rsa_private_to_pem, rsa_public_from_pem, encrypt_layer, decrypt_layer as decrypt};
+use std::path::Path;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let (priv_key, _pub_key) = load_or_generate_keys("exit_node/keys");
+    let listener = TcpListener::bind("127.0.0.1:7002").await?;
+    println!("Exit node listening on 7002");
+    loop {
+        let (mut socket, _) = listener.accept().await?;
+        let priv_key = priv_key.clone();
+        tokio::spawn(async move {
+            if let Err(e) = handle_client(&priv_key, &mut socket).await {
+                eprintln!("exit node error: {e}");
+            }
+        });
+    }
+}
+
+fn load_service_key(domain: &str) -> rsa::RsaPrivateKey {
+    let dir = Path::new("services").join(domain);
+    std::fs::create_dir_all(&dir).ok();
+    let priv_path = dir.join("private.pem");
+    if priv_path.exists() {
+        let pem = std::fs::read_to_string(priv_path).expect("read service key");
+        rsa_private_from_pem(&pem)
+    } else {
+        let (priv_k, pub_k) = shared::crypto::generate_rsa_keys();
+        std::fs::write(dir.join("private.pem"), rsa_private_to_pem(&priv_k)).unwrap();
+        std::fs::write(dir.join("public.pem"), rsa_public_to_pem(&pub_k)).unwrap();
+        priv_k
+    }
+}
+
+async fn handle_client(priv_key: &rsa::RsaPrivateKey, socket: &mut TcpStream) -> anyhow::Result<()> {
+    let mut reader = BufReader::new(socket);
+    let mut line = String::new();
+    reader.read_line(&mut line).await?;
+    let layer: shared::crypto::OnionLayer = serde_json::from_str(&line.trim())?;
+    let decrypted = decrypt_layer(layer, priv_key);
+    let hop: ExitHop = serde_json::from_slice(&decrypted)?;
+    println!("Exit -> delivering to {}", hop.domain);
+    let service_priv = load_service_key(&hop.domain);
+    let inner_layer: shared::crypto::OnionLayer = serde_json::from_slice(&general_purpose::STANDARD.decode(hop.inner)? )?;
+    let garlic_bytes = decrypt(inner_layer, &service_priv);
+    let packet: GarlicPacket = serde_json::from_slice(&garlic_bytes)?;
+    for msg in packet.messages {
+        println!("Service {} received: {}", msg.destination, msg.body);
+    }
+    Ok(())
+}

--- a/onyx-core/middle_node/Cargo.toml
+++ b/onyx-core/middle_node/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "middle_node"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+shared = { path = "../shared" }
+tokio = { version = "1", features = ["full"] }
+serde_json = "1"
+anyhow = "1"
+base64 = "0.21"
+rsa = "0.9"

--- a/onyx-core/middle_node/src/main.rs
+++ b/onyx-core/middle_node/src/main.rs
@@ -1,0 +1,37 @@
+use shared::crypto::{load_or_generate_keys, decrypt_layer};
+use shared::packet::HopData;
+use tokio::{net::{TcpListener, TcpStream}, io::{AsyncWriteExt, AsyncBufReadExt, BufReader}};
+use base64::{engine::general_purpose, Engine as _};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let (priv_key, _pub_key) = load_or_generate_keys("middle_node/keys");
+    let listener = TcpListener::bind("127.0.0.1:7001").await?;
+    println!("Middle node listening on 7001");
+    loop {
+        let (mut socket, _) = listener.accept().await?;
+        let priv_key = priv_key.clone();
+        tokio::spawn(async move {
+            if let Err(e) = handle_client(&priv_key, &mut socket).await {
+                eprintln!("middle node error: {e}");
+            }
+        });
+    }
+}
+
+async fn handle_client(priv_key: &rsa::RsaPrivateKey, socket: &mut TcpStream) -> anyhow::Result<()> {
+    let mut reader = BufReader::new(socket);
+    let mut line = String::new();
+    reader.read_line(&mut line).await?;
+    let layer: shared::crypto::OnionLayer = serde_json::from_str(&line.trim())?;
+    let decrypted = decrypt_layer(layer, priv_key);
+    let hop: HopData = serde_json::from_slice(&decrypted)?;
+    if let Some(next) = hop.next {
+        println!("Middle -> forwarding to {next}");
+        let inner = general_purpose::STANDARD.decode(hop.inner)?;
+        let mut stream = TcpStream::connect(next).await?;
+        stream.write_all(&inner).await?;
+        stream.write_all(b"\n").await?;
+    }
+    Ok(())
+}

--- a/onyx-core/services.txt
+++ b/onyx-core/services.txt
@@ -1,0 +1,1 @@
+echo.ony exit_node/services/echo.ony/public.pem

--- a/onyx-core/shared/Cargo.toml
+++ b/onyx-core/shared/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "shared"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+rand = "0.8"
+aes-gcm = "0.10"
+aes = "0.8"
+rsa = "0.9"
+sha2 = "0.10"
+base64 = "0.21"
+once_cell = "1"

--- a/onyx-core/shared/src/crypto.rs
+++ b/onyx-core/shared/src/crypto.rs
@@ -1,0 +1,81 @@
+use aes_gcm::{Aes256Gcm, aead::{Aead, KeyInit, OsRng, generic_array::GenericArray}};
+use rsa::{RsaPrivateKey, RsaPublicKey, pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePrivateKey, EncodePublicKey}};
+use rand::rngs::OsRng as RandOsRng;
+use rsa::Oaep;
+use sha2::Sha256;
+use base64::{engine::general_purpose, Engine as _};
+
+pub fn generate_rsa_keys() -> (RsaPrivateKey, RsaPublicKey) {
+    let mut rng = RandOsRng;
+    let bits = 2048;
+    let priv_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate key");
+    let pub_key = RsaPublicKey::from(&priv_key);
+    (priv_key, pub_key)
+}
+
+pub fn rsa_public_to_pem(pub_key: &RsaPublicKey) -> String {
+    pub_key.to_public_key_pem(rsa::pkcs8::LineEnding::LF).expect("pem")
+}
+
+pub fn rsa_private_to_pem(priv_key: &RsaPrivateKey) -> String {
+    priv_key.to_pkcs8_pem(rsa::pkcs8::LineEnding::LF).expect("pem").to_string()
+}
+
+pub fn rsa_private_from_pem(pem: &str) -> RsaPrivateKey {
+    RsaPrivateKey::from_pkcs8_pem(pem).expect("invalid pem")
+}
+
+pub fn rsa_public_from_pem(pem: &str) -> RsaPublicKey {
+    RsaPublicKey::from_public_key_pem(pem).expect("invalid pem")
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct OnionLayer {
+    pub encrypted_key: String,
+    pub nonce: String,
+    pub ciphertext: String,
+}
+
+pub fn encrypt_layer(data: &[u8], pub_key: &RsaPublicKey) -> OnionLayer {
+    let aes_key = Aes256Gcm::generate_key(&mut OsRng);
+    let cipher = Aes256Gcm::new(&aes_key);
+    let nonce = aes_gcm::Nonce::from_slice(&rand::random::<[u8; 12]>());
+    let ciphertext = cipher.encrypt(nonce, data).expect("encrypt");
+    let mut rng = RandOsRng;
+    let enc_key = pub_key.encrypt(&mut rng, Oaep::new::<Sha256>(), &aes_key).expect("rsa enc");
+    OnionLayer {
+        encrypted_key: general_purpose::STANDARD.encode(enc_key),
+        nonce: general_purpose::STANDARD.encode(nonce),
+        ciphertext: general_purpose::STANDARD.encode(ciphertext),
+    }
+}
+
+pub fn decrypt_layer(layer: OnionLayer, priv_key: &RsaPrivateKey) -> Vec<u8> {
+    let enc_key = general_purpose::STANDARD.decode(layer.encrypted_key).expect("b64");
+    let aes_key = priv_key.decrypt(Oaep::new::<Sha256>(), &enc_key).expect("dec key");
+    let cipher = Aes256Gcm::new(GenericArray::from_slice(&aes_key));
+    let nonce_bytes = general_purpose::STANDARD.decode(layer.nonce).expect("b64");
+    let nonce = aes_gcm::Nonce::from_slice(&nonce_bytes);
+    let ciphertext = general_purpose::STANDARD.decode(layer.ciphertext).expect("b64");
+    cipher.decrypt(nonce, ciphertext.as_ref()).expect("decrypt")
+}
+use std::fs;
+use std::path::Path;
+
+pub fn load_or_generate_keys(dir: &str) -> (RsaPrivateKey, RsaPublicKey) {
+    let priv_path = Path::new(dir).join("private.pem");
+    let pub_path = Path::new(dir).join("public.pem");
+    if priv_path.exists() && pub_path.exists() {
+        let priv_pem = fs::read_to_string(&priv_path).expect("read priv");
+        let pub_pem = fs::read_to_string(&pub_path).expect("read pub");
+        let priv_key = rsa_private_from_pem(&priv_pem);
+        let pub_key = rsa_public_from_pem(&pub_pem);
+        (priv_key, pub_key)
+    } else {
+        let (priv_key, pub_key) = generate_rsa_keys();
+        fs::create_dir_all(dir).ok();
+        fs::write(&priv_path, rsa_private_to_pem(&priv_key)).expect("write");
+        fs::write(&pub_path, rsa_public_to_pem(&pub_key)).expect("write");
+        (priv_key, pub_key)
+    }
+}

--- a/onyx-core/shared/src/lib.rs
+++ b/onyx-core/shared/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod crypto;
+pub mod packet;
+pub mod resolver;

--- a/onyx-core/shared/src/packet.rs
+++ b/onyx-core/shared/src/packet.rs
@@ -1,0 +1,30 @@
+use serde::{Serialize, Deserialize};
+use crate::crypto::OnionLayer;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Message {
+    pub destination: String,
+    pub body: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GarlicPacket {
+    pub messages: Vec<Message>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct OnionPacket {
+    pub layers: Vec<OnionLayer>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct HopData {
+    pub next: Option<String>,
+    pub inner: String, // base64 of next layer or garlic packet
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ExitHop {
+    pub domain: String,
+    pub inner: String, // base64 of garlic packet encrypted with service key
+}

--- a/onyx-core/shared/src/resolver.rs
+++ b/onyx-core/shared/src/resolver.rs
@@ -1,0 +1,25 @@
+use std::collections::HashMap;
+use std::fs;
+use std::sync::Mutex;
+use once_cell::sync::Lazy;
+use rsa::RsaPublicKey;
+use crate::crypto::rsa_public_from_pem;
+
+static RESOLVER: Lazy<Mutex<HashMap<String, RsaPublicKey>>> = Lazy::new(|| {
+    Mutex::new(HashMap::new())
+});
+
+pub fn load_resolver(path: &str) {
+    let data = fs::read_to_string(path).expect("resolver file");
+    let mut map = RESOLVER.lock().unwrap();
+    for line in data.lines() {
+        if let Some((domain, key_pem)) = line.split_once(' ') {
+            map.insert(domain.to_string(), rsa_public_from_pem(key_pem));
+        }
+    }
+}
+
+pub fn resolve(domain: &str) -> Option<RsaPublicKey> {
+    let map = RESOLVER.lock().unwrap();
+    map.get(domain).cloned()
+}


### PR DESCRIPTION
## Summary
- implement basic 3-hop routing system using RSA and AES-GCM
- add entry, middle and exit nodes plus client
- provide shared crypto utils and packet/resolver logic
- document how to run the nodes

## Testing
- `cargo build --workspace` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684618dc221883218490d4b41b9a14c1